### PR TITLE
Remove git dependency in gemspec?

### DIFF
--- a/barby.gemspec
+++ b/barby.gemspec
@@ -16,8 +16,6 @@ Gem::Specification.new do |s|
   s.has_rdoc         = true
   s.extra_rdoc_files = ["README"]
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- spec/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files         = Dir['CHANGELOG', 'README', 'LICENSE', 'lib/**/*', 'vendor/**/*']
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
Passenger didn't like using 'git ls-files', so replace it with a static list instead.
