### PR TITLE
Have test working with ruby 1.9.2

### DIFF
--- a/test/bookland_test.rb
+++ b/test/bookland_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require './test/test_helper'
 require 'barby/barcode/bookland'
 
 class BooklandTest < Barby::TestCase

--- a/test/code_128_test.rb
+++ b/test/code_128_test.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-require 'test_helper'
+require './test/test_helper'
 require 'barby/barcode/code_128'
 
 class Code128Test < Barby::TestCase

--- a/test/code_25_iata_test.rb
+++ b/test/code_25_iata_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require './test/test_helper'
 require 'barby/barcode/code_25_iata'
 
 class Code25IATATest < Barby::TestCase

--- a/test/code_25_interleaved_test.rb
+++ b/test/code_25_interleaved_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require './test/test_helper'
 require 'barby/barcode/code_25_interleaved'
 
 class Code25InterleavedTest < Barby::TestCase

--- a/test/code_25_test.rb
+++ b/test/code_25_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require './test/test_helper'
 require 'barby/barcode/code_25'
 
 class Code25Test < Barby::TestCase

--- a/test/code_39_test.rb
+++ b/test/code_39_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require './test/test_helper'
 require 'barby/barcode/code_39'
 
 class Code39Test < Barby::TestCase

--- a/test/code_93_test.rb
+++ b/test/code_93_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require './test/test_helper'
 require 'barby/barcode/code_93'
 
 class Code93Test < Barby::TestCase

--- a/test/data_matrix_test.rb
+++ b/test/data_matrix_test.rb
@@ -1,6 +1,6 @@
 unless RUBY_VERSION >= '1.9'
 
-  require 'test_helper'
+  require './test/test_helper'
   require 'barby/barcode/data_matrix'
 
   class DataMatrixTest < Barby::TestCase

--- a/test/ean13_test.rb
+++ b/test/ean13_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require './test/test_helper'
 require 'barby/barcode/ean_13'
 
 class EAN13Test < Barby::TestCase

--- a/test/ean8_test.rb
+++ b/test/ean8_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require './test/test_helper'
 require 'barby/barcode/ean_8'
 
 class EAN8Test < Barby::TestCase

--- a/test/gs1_128_test.rb
+++ b/test/gs1_128_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require './test/test_helper'
 require 'barby/barcode/gs1_128'
 
 class GS1128Test < Barby::TestCase

--- a/test/outputter_test.rb
+++ b/test/outputter_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require './test/test_helper'
 
 class OutputterTest < Barby::TestCase
 

--- a/test/pdf_417_test.rb
+++ b/test/pdf_417_test.rb
@@ -1,6 +1,6 @@
 if defined? JRUBY_VERSION
 
-  require 'test_helper'
+  require './test/test_helper'
   require 'barby/barcode/pdf_417'
 
   class Pdf417Test < Barby::TestCase

--- a/test/qr_code_test.rb
+++ b/test/qr_code_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require './test/test_helper'
 require 'barby/barcode/qr_code'
 
 class QrCodeTest < Barby::TestCase


### PR DESCRIPTION
Small modifications on the require "spec_helper" in the test files to have tests working with ruby 1.9.2.

How to test it:
- rvm use ruby-1.9.2
- bundle exec rake test
