### PR TITLE
HTML outputter is not printable

### DIFF
--- a/lib/barby/outputter/html_outputter.rb
+++ b/lib/barby/outputter/html_outputter.rb
@@ -30,7 +30,10 @@ module Barby
           margin: 0 !important;
           padding: 0 !important;
         }
-        table.barby_code tr.barby_row td { border: 0 none transparent !important; }
+        table.barby_code tr.barby_row td {
+          border: 0 none transparent !important;
+          padding: 0 !important;
+        }
         table.barby_code tr.barby_row td.barby_black { border-right: 1px black solid !important; }
         table.barby_code tr.barby_row td.barby_white { border-right: 1px white solid !important; }
       CSS


### PR DESCRIPTION
The HTML outputter sets a `background-color` on `<td>`s in order to display the barcode: 

```
table.barby_code tr.barby_row td.barby_black { background-color: black !important; }
table.barby_code tr.barby_row td.barby_white { background-color: white !important; }
```

But because [print views don't support background colors](http://css-tricks.com/dont-rely-on-background-colors-printing/), the barcode don't display whenever printing. The fix is pretty simple. Set colors using `border-right` rather than `background-color`:

```
table.barby_code tr.barby_row td.barby_black { border-right: 1px black solid !important; }
table.barby_code tr.barby_row td.barby_white { border-right: 1px white solid !important; }
```

The barcode renders as before but now prints properly as well.

Because the tests dynamically include the CSS, no updates were necessary. Everything still passes.

Thanks for building this!
Cory
