### PR TITLE
Fixes support for 2d barcodes with RmagickOutputter

### DIFF
--- a/lib/barby/outputter/rmagick_outputter.rb
+++ b/lib/barby/outputter/rmagick_outputter.rb
@@ -46,26 +46,35 @@ module Barby
         canvas = Magick::Image.new(full_width, full_height)
         bars = Magick::Draw.new
 
-        x = margin
-        y = margin
+        x1 = margin
+        y1 = margin
 
         if barcode.two_dimensional?
           encoding.each do |line|
             line.split(//).map{|c| c == '1' }.each do |bar|
               if bar
-                bars.rectangle(x, y, x+(xdim-1), y+(ydim-1))
+                x2 = x1+(xdim-1)
+                y2 = y1+(ydim-1)
+                # For single pixels use point
+                if x1 == x2 && y1 == y2
+                  bars.point(x1,y1)
+                else
+                  bars.rectangle(x1, y1, x2, y2)
+                end
               end
-              x += xdim
+              x1 += xdim
             end
-            x = margin
-            y += ydim
+            x1 = margin
+            y1 += ydim
           end
         else
           booleans.each do |bar|
             if bar
-              bars.rectangle(x, y, x+(xdim-1), y+(height-1))
+              x2 = x1+(xdim-1)
+              y2 = y1+(height-1)
+              bars.rectangle(x1, y1, x2, y2)
             end
-            x += xdim
+            x1 += xdim
           end
         end
 


### PR DESCRIPTION
This commit fixes issues with RmagickOutputter and 2d barcodes. When using QrCode we were getting `non-conforming drawing primitive definition 'rectangle'` error messages from Rmagick. It seems to be caused by the 1px by 1px rectangles. This could probably use some specific tests as well, but it resolved our issue with it.
