### PR TITLE
require recent rmagick without deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ require 'barby/outputter/<filename>_outputter'
 | `pdfwriter` | ─             |
 | `png`       | chunky_png    |
 | `prawn`     | prawn         |
-| `rmagick`   | RMagick       |
+| `rmagick`   | rmagick       |
 | `svg`       | ─             |
 
 ### Formats supported by outputters

--- a/lib/barby/outputter/rmagick_outputter.rb
+++ b/lib/barby/outputter/rmagick_outputter.rb
@@ -1,5 +1,5 @@
 require 'barby/outputter'
-require 'RMagick'
+require 'rmagick'
 
 module Barby
 


### PR DESCRIPTION
since rmagick 2.14, this commit of theirs:
https://github.com/gemhome/rmagick/commit/77827346b046c6e42ce27909970036d7cc1f16de