### PR TITLE
Require 'rmagick' instead of 'RMagick'

### DIFF
--- a/lib/barby/outputter/rmagick_outputter.rb
+++ b/lib/barby/outputter/rmagick_outputter.rb
@@ -1,5 +1,5 @@
 require 'barby/outputter'
-require 'RMagick'
+require 'rmagick'
 
 module Barby
 


### PR DESCRIPTION
To resolve this deprecation warning:

[DEPRECATION] requiring "RMagick" is deprecated. Use "rmagick" instead