### PR TITLE
Add hidden support to Code 39 extended and mention to 128A, B, and C

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ require 'barby/barcode/<filename>'
 | ├─ Interleaved                      | `code_25_interleaved` | ─             |
 | └─ IATA                             | `code_25_iata`        | ─             |
 | Code 39                             | `code_39`             | ─             |
+| └─ Extended                         | `code_39`             | ─             |
 | Code 93                             | `code_93`             | ─             |
-| Code 128                            | `code_128`            | ─             |
+| Code 128 (A, B, and C)              | `code_128`            | ─             |
 | └─ GS1 128                          | `gs1_128`             | ─             |
 | EAN-13                              | `ean_13`              | ─             |
 | ├─ Bookland                         | `bookland`            | ─             |


### PR DESCRIPTION
Changes:
* Document support to Code 39 Extended
* Mention Code 128 sub-types A, B, and C in the main README.md