### PR TITLE
Fixes GS1-128 barcodes without type given

### DIFF
--- a/lib/barby/barcode/gs1_128.rb
+++ b/lib/barby/barcode/gs1_128.rb
@@ -7,20 +7,12 @@ module Barby
   class GS1128 < Code128
 
     attr_accessor :application_identifier
+    attr_reader :partial_data
 
-    def initialize(data, type, ai)
+    def initialize(partial_data, type, ai)
+      @partial_data = partial_data
       self.application_identifier = ai
-      super(data, type)
-    end
-
-
-    #TODO: Not sure this is entirely right
-    def data
-      FNC1+application_identifier+super
-    end
-
-    def partial_data
-      @data
+      super("#{FNC1}#{application_identifier}#{partial_data}", type)
     end
 
     def application_identifier_number

--- a/test/gs1_128_test.rb
+++ b/test/gs1_128_test.rb
@@ -65,4 +65,43 @@ class GS1128Test < Barby::TestCase
     @code.to_s.must_equal '(11) 071230'
   end
 
+  it "should work without explictly stating the type" do
+    code = GS1128.new('27638268+99000900251033', nil, '403')
+
+    ([code.start_num] + code.numbers + code.extra_numbers).must_equal(
+      [
+        value_for_code_b(GS1128::STARTB),
+        value_for_code_b(GS1128::FNC1),
+        value_for_code_b("4"),
+        value_for_code_b(GS1128::CODEC),
+        value_for_code_c("03"),
+        value_for_code_c("27"),
+        value_for_code_c("63"),
+        value_for_code_c("82"),
+        value_for_code_c("68"),
+        value_for_code_c(GS1128::CODEB),
+        value_for_code_b("+"),
+        value_for_code_b(GS1128::CODEC),
+        value_for_code_c("99"),
+        value_for_code_c("00"),
+        value_for_code_c("09"),
+        value_for_code_c("00"),
+        value_for_code_c("25"),
+        value_for_code_c("10"),
+        value_for_code_c("33"),
+      ]
+    )
+  end
+
+  def value_for_code_a(char)
+    GS1128::VALUES['A'][char]
+  end
+
+  def value_for_code_b(char)
+    GS1128::VALUES['B'][char]
+  end
+
+  def value_for_code_c(char)
+    GS1128::VALUES['C'][char]
+  end
 end


### PR DESCRIPTION
Fixes the the GS1-128 barcode generate for the case when no type is given:

Due to the fact, that the ```GS1128#initialize``` method was not giving
the correct data to the initialize and that the overwritten
```GS1128#data``` returned a different string then what was given in the
```initialize``` method, the ```valid?``` method returned false.

This commit adjusts the initializer so it builds the correct data string
(including the ```FNC1``` symbol at the application identifier)
and removes the data method from the GS1128 class.