### PR TITLE
Optimize Use of Codeset C for GS1-128 Barcodes

### DIFF
--- a/lib/barby/barcode/code_128.rb
+++ b/lib/barby/barcode/code_128.rb
@@ -424,7 +424,7 @@ module Barby
       #shortest encoding possible
       def apply_shortest_encoding_for_data(data)
         extract_codec(data).map do |block|
-          if possible_codec_segment?(block)
+          if codec_segment?(block)
             "#{CODEC}#{block}"
           else
             if control_before_lowercase?(block)
@@ -454,25 +454,15 @@ module Barby
       #  #                                        C       A or B  C         A or B
       #  extract_codec("12345abc678910DEF11") => ["1234", "5abc", "678910", "DEF11"]
       def extract_codec(data)
-        segments = data.split(/(\d{4,})/).reject(&:empty?)
-        segments.each_with_index do |s,i|
-          if possible_codec_segment?(s) && s.size.odd?
-            if i == 0
-              if segments[1]
-                segments[1].insert(0, s.slice!(-1))
-              else
-                segments[1] = s.slice!(-1)
-              end
-            else
-              segments[i-1].insert(-1, s.slice!(0)) if segments[i-1]
-            end
-          end
-        end
-        segments
+        data.split(/
+          ((?:^(?:(?:\d{2}){2,})))
+          |
+          ((?:(?:(?:\d{2}){2,})(?!\d)))
+        /x).reject(&:empty?)
       end
 
-      def possible_codec_segment?(data)
-        data =~ /\A\d{4,}\Z/
+      def codec_segment?(data)
+        data =~ /\A(?:\d{2}|#{FNC1}){2,}\Z/
       end
 
       def control_character?(char)

--- a/lib/barby/barcode/code_128.rb
+++ b/lib/barby/barcode/code_128.rb
@@ -455,9 +455,9 @@ module Barby
       #  extract_codec("12345abc678910DEF11") => ["1234", "5abc", "678910", "DEF11"]
       def extract_codec(data)
         data.split(/
-          ((?:^(?:(?:\d{2}){2,})))
+          ((?:^(?:(?:\d{2}|#{FNC1}){2,}))) # matches digits that appear at the beginning of the barcode
           |
-          ((?:(?:(?:\d{2}){2,})(?!\d)))
+          ((?:(?:(?:\d{2}|#{FNC1}){2,})(?!\d))) # matches digits that appear later in the barcode
         /x).reject(&:empty?)
       end
 

--- a/lib/barby/barcode/code_128.rb
+++ b/lib/barby/barcode/code_128.rb
@@ -405,6 +405,9 @@ module Barby
     LOWR_RE = /[a-z]/
     DGTS_RE = /\d{4,}/
 
+    # pairs of digits and FNC characters
+    CODEC_CHARS_RE = /(?:\d{2}|#{FNC1}){2,}/
+
     class << self
 
 
@@ -455,9 +458,9 @@ module Barby
       #  extract_codec("12345abc678910DEF11") => ["1234", "5abc", "678910", "DEF11"]
       def extract_codec(data)
         data.split(/
-          ((?:^(?:(?:\d{2}|#{FNC1}){2,}))) # matches digits that appear at the beginning of the barcode
+          ((?:^(?:#{CODEC_CHARS_RE}))) # matches digits that appear at the beginning of the barcode
           |
-          ((?:(?:(?:\d{2}|#{FNC1}){2,})(?!\d))) # matches digits that appear later in the barcode
+          ((?:(?:#{CODEC_CHARS_RE})(?!\d))) # matches digits that appear later in the barcode
         /x).reject(&:empty?)
       end
 

--- a/lib/barby/barcode/code_128.rb
+++ b/lib/barby/barcode/code_128.rb
@@ -458,9 +458,9 @@ module Barby
       #  extract_codec("12345abc678910DEF11") => ["1234", "5abc", "678910", "DEF11"]
       def extract_codec(data)
         data.split(/
-          ((?:^(?:#{CODEC_CHARS_RE}))) # matches digits that appear at the beginning of the barcode
+          (^(?:#{CODEC_CHARS_RE})) # matches digits that appear at the beginning of the barcode
           |
-          ((?:(?:#{CODEC_CHARS_RE})(?!\d))) # matches digits that appear later in the barcode
+          ((?:#{CODEC_CHARS_RE})(?!\d)) # matches digits that appear later in the barcode
         /x).reject(&:empty?)
       end
 

--- a/lib/barby/barcode/code_128.rb
+++ b/lib/barby/barcode/code_128.rb
@@ -405,7 +405,7 @@ module Barby
     LOWR_RE = /[a-z]/
     DGTS_RE = /\d{4,}/
 
-    # pairs of digits and FNC characters
+    # pairs of digits and FNC1 characters
     CODEC_CHARS_RE = /(?:\d{2}|#{FNC1}){2,}/
 
     class << self
@@ -465,7 +465,7 @@ module Barby
       end
 
       def codec_segment?(data)
-        data =~ /\A(?:\d{2}|#{FNC1}){2,}\Z/
+        data =~ /\A#{CODEC_CHARS_RE}\Z/
       end
 
       def control_character?(char)

--- a/test/code_128_test.rb
+++ b/test/code_128_test.rb
@@ -430,7 +430,6 @@ class Code128Test < Barby::TestCase
     end
 
     it "should know how to most efficiently apply different encodings to a data string" do
-      #Code128.apply_shortest_encoding_for_data("#{FNC1}10LOT").must_equal "#{CODEC}#{FNC1}10#{CODEB}LOT"
       Code128.apply_shortest_encoding_for_data("123456").must_equal "#{CODEC}123456"
       Code128.apply_shortest_encoding_for_data("abcdef").must_equal "#{CODEB}abcdef"
       Code128.apply_shortest_encoding_for_data("ABCDEF").must_equal "#{CODEB}ABCDEF"

--- a/test/code_128_test.rb
+++ b/test/code_128_test.rb
@@ -370,6 +370,7 @@ class Code128Test < Barby::TestCase
     end
 
     it "should know how to most efficiently apply different encodings to a data string" do
+      Code128.apply_shortest_encoding_for_data("#{FNC1}10LOT").must_equal "#{CODEC}#{FNC1}10#{CODEB}LOT"
       Code128.apply_shortest_encoding_for_data("123456").must_equal "#{CODEC}123456"
       Code128.apply_shortest_encoding_for_data("abcdef").must_equal "#{CODEB}abcdef"
       Code128.apply_shortest_encoding_for_data("ABCDEF").must_equal "#{CODEB}ABCDEF"


### PR DESCRIPTION
## Summary

At present, barby does not optimally minimize the length of generated GS1-128 barcodes.

Our pull request modifies the existing minimization algorithm to properly account for FNC1 characters when choosing to switch to codeset C. We have also added a GS1-128 test suite to validate conformance to the GS1 specification reproduced below.
## Details

**Given the barcode data:** `[FNC1]10123456[FNC1]2099`

The barcode is encoded as follows:

**With the current implementation:** `[STARTB][FNC1][CODEC]10123456[CODEB][FNC1][CODEC]2099`

**After our proposed changes**: `[STARTC][FNC1]10123456[FNC1]2099`

This breaks certain barcode scanners that impose very strict requirements on the width of GS1-128 barcodes.

We did notice that barby currently implements most of the guidelines offered by the _GS1 General Specifications, Version 15 (issue 2)_ to minimize the length of generated barcodes. However, optimal handling of FNC1 characters in GS1-128 barcodes is currently missing.  

We have reproduced the relevant section of the specification below:

```
5.4.7.7. Use of Start, Code Set, and Shift Characters to Minimize Symbol Length (Informative)

  The same data may be represented by different GS1-128 barcodes through the use of different combinations of Start, code set, and shift characters.

  The following rules should normally be implemented in printer control software to minimise the number of symbol characters needed to represent a given data string (and, therefore, reduce the overall symbol length).

  * Determine the Start Character:
  - If the data consists of two digits, use Start Character C.
  - If the data begins with four or more numeric data characters, use Start Character C.
  - If an ASCII symbology element (e.g., NUL) occurs in the data before any lowercase character, use Start Character A.
  - Otherwise, use Start Character B.
  * If Start Character C is used and the data begins with an odd number of numeric data characters, insert a code set A or code set B character before the last digit, following rules 1c and 1d to determine between code sets A and B.
  * If four or more numeric data characters occur together when in code sets A or B and:
  - If there is an even number of numeric data characters, then insert a code set C character before the first numeric digit to change to code set C.
  - If there is an odd number of numeric data characters, then insert a code set C character immediately after the first numeric digit to change to code set C.
  * When in code set B and an ASCII symbology element occurs in the data:
  - If following that character, a lowercase character occurs in the data before the occurrence of another symbology element, then insert a shift character before the symbology element.
  - Otherwise, insert a code set A character before the symbology element to change to code set A.
  * When in code set A and a lowercase character occurs in the data:
  - If following that character, a symbology element occurs in the data before the occurrence of another lowercase character, then insert a shift character before the lowercase character.
  - Otherwise, insert a code set B character before the lowercase character to change to code set B.
  When in code set C and a non-numeric character occurs in the data, insert a code set A or code set B character before that character, and follow rules 1c and 1d to determine between code sets A and B.

  Note: In these rules, the term “lowercase” is used for convenience to mean any code set B character with Code 128 Symbol character values 64 to 95 (ASCII values 96 to 127) (e.g., all lowercase alphanumeric characters plus `{|}~DEL). The term “symbology element” means any code set A character with Code 128 Symbol character values 64 to 95 (ASCII values 00 to 31).
  Note 2: If the Function 1 Symbol Character (FNC1) occurs in the first position following the Start Character, or in an odd-numbered position in a numeric field, it should be treated as two digits for the purpose of determining the appropriate code set.
```

We would like to highlight the following rule:

`Note 2: If the Function 1 Symbol Character (FNC1) occurs in the first position following the Start Character, or in an odd-numbered position in a numeric field, it should be treated as two digits for the purpose of determining the appropriate code set.`

The current minimization algorithm employed fails to adhere to this guideline, and treats FNC1 characters as non-codeset C characters. This results in unnecessary switching from codeset C to one of codeset A or B, and significantly increases the length of the generated barcode.
