### PR TITLE
[ENHANCE] Provide Development Dependency to Easily Setup Initial Test Run for Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gemspec

--- a/barby.gemspec
+++ b/barby.gemspec
@@ -16,8 +16,17 @@ Gem::Specification.new do |s|
   s.has_rdoc          = true
   s.extra_rdoc_files  = ["README.md"]
 
-  s.files             = Dir['CHANGELOG', 'README.md', 'LICENSE', 'lib/**/*', 'vendor/**/*', 'bin/*']
-  #s.executables       = ['barby'] #WIP, doesn't really work that well
+  s.files         = `git ls-files`.split("\n")
+  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.test_files.delete("test/outputter/rmagick_outputter_test.rb")
+  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths     = ["lib"]
 
+  s.add_development_dependency "minitest",        "~> 5.11"
+  s.add_development_dependency "bundler",         "~> 1.16"
+  s.add_development_dependency "rake",            "~> 10.0"
+  s.add_development_dependency "semacode-ruby19", "~> 0.7"
+  s.add_development_dependency "rqrcode",         "~> 0.10"
+  s.add_development_dependency "prawn",           "~> 2.2"
+  s.add_development_dependency "cairo",           "~> 1.15"
 end

--- a/test/outputter/rmagick_outputter_test.rb
+++ b/test/outputter/rmagick_outputter_test.rb
@@ -16,7 +16,7 @@ class RmagickOutputterTest < Barby::TestCase
     @barcode = RmagickTestBarcode.new('10110011100011110000')
     @outputter = RmagickOutputter.new(@barcode)
   end
-  
+
   it "should register to_png, to_gif, to_jpg, to_image" do
     Barcode.outputters.must_include(:to_png)
     Barcode.outputters.must_include(:to_gif)
@@ -62,10 +62,10 @@ class RmagickOutputterTest < Barby::TestCase
   it "should have a full_height equal to the height + top and bottom margins" do
     @outputter.full_height.must_equal @outputter.height + (@outputter.margin * 2)
   end
-  
+
   describe "#to_image" do
 
-    before do 
+    before do
       @barcode = RmagickTestBarcode.new('10110011100011110000')
       @outputter = RmagickOutputter.new(@barcode)
       @image = @outputter.to_image

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,11 +13,12 @@ module Barby
     # So we can register outputter during an full test suite run.
     def load_outputter(outputter)
       @loaded_outputter ||= load "barby/outputter/#{outputter}_outputter.rb"
+    rescue LoadError => e
+      skip "#{outputter} not being installed properly"
     end
 
     def ruby_19_or_greater?
       RUBY_VERSION >= '1.9'
     end
-
   end
 end


### PR DESCRIPTION
### Objective

Since I'm currently working on a new PR feature for the gem (Minimagick outputter), I found that the `gemspec` didn't specify anything required for making the test run completely. Therefore, I specify some dependencies for new maitainers to easily setup the initial test run for the gem.

### Feature

- Add some gem dependencies for the test run