### PR TITLE
Remove deprecated #has_rdoc from gemspec

### DIFF
--- a/barby.gemspec
+++ b/barby.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "barby"
 
-  s.has_rdoc          = true
   s.extra_rdoc_files  = ["README.md"]
 
   s.files             = Dir['CHANGELOG', 'README.md', 'LICENSE', 'lib/**/*', 'vendor/**/*', 'bin/*']


### PR DESCRIPTION
Quite simple change. 

Solves the deprecation warning:

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /path/to/barby-commit-sha/barby.gemspec:16.
```
