### PR TITLE
RMagick outputter should use line command for lines

### DIFF
--- a/lib/barby/outputter/rmagick_outputter.rb
+++ b/lib/barby/outputter/rmagick_outputter.rb
@@ -64,7 +64,14 @@ module Barby
                 if x1 == x2 && y1 == y2
                   bars.point(x1,y1)
                 else
-                  bars.rectangle(x1, y1, x2, y2)
+                  # For single pixel lines, use line
+                  if x1 == x2
+                    bars.line(x1, y1, x1, y2)
+                  elsif y1 == y2
+                    bars.line(x1, y1, x2, y1)
+                  else
+                    bars.rectangle(x1, y1, x2, y2)
+                  end
                 end
               end
               x1 += xdim
@@ -77,7 +84,12 @@ module Barby
             if bar
               x2 = x1+(xdim-1)
               y2 = y1+(height-1)
-              bars.rectangle(x1, y1, x2, y2)
+              # For single pixel width, use line
+              if x1 == x2
+                bars.line(x1, y1, x1, y2)
+              else
+                bars.rectangle(x1, y1, x2, y2)
+              end
             end
             x1 += xdim
           end


### PR DESCRIPTION
Newer versions of ImageMagick do not support creating
rectangles that are only a single pixel wide.
https://www.imagemagick.org/discourse-server/viewtopic.php?f=3&p=166063

When drawing a single pixel wide (or tall) line, use
the `#line` command instead of `rectangle`.

This works on older version of ImageMagick like 6.9.6-2
(which supported single pixel wide rectangles), as well
as newer versions like 6.9.10-6 and 7.0.8 (which do NOT
support single pixel wide rectangles).