### PR TITLE
add dependency chunk_png

### DIFF
--- a/barby.gemspec
+++ b/barby.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths     = ["lib"]
 
+  s.add_dependency "chunky_png"
   s.add_development_dependency "minitest",        "~> 5.11"
   s.add_development_dependency "bundler",         "~> 1.16"
   s.add_development_dependency "rake",            "~> 10.0"


### PR DESCRIPTION
# Background

I run the sample code caused error.
Error tells to me add chunky_png.
So add chunky_png gems as dependency.

### sample

```ruby
require 'barby'
require 'barby/barcode/code_128'
require 'barby/outputter/png_outputter'

barcode = Barby::Code128.new('sample')
File.open('code128.png', 'w'){|f|
  f.write barcode.to_png(:height => 20, :margin => 5)
}
```

### error code

```shell
 → bundle exec ruby sample.rb
/project/to/path/vendor/bundle/gems/barby-0.6.8/lib/barby/outputter/png_outputter.rb:2:in `require': cannot load such file -- chunky_png (LoadError)
        from /Users/4geru/train/qr-coders/vendor/bundle/gems/barby-0.6.8/lib/barby/outputter/png_outputter.rb:2:in `<top (required)>'
        from sample.rb:3:in `require'
        from sample.rb:3:in `<main>'
```