### PR TITLE
Remove deprecated option from gemspec

### DIFF
--- a/barby.gemspec
+++ b/barby.gemspec
@@ -11,8 +11,6 @@ Gem::Specification.new do |s|
   s.description = "Barby creates barcodes."
   s.authors     = ['Tore Darell']
 
-  s.rubyforge_project = "barby"
-
   s.extra_rdoc_files  = ["README.md"]
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
This is deprecated by rubygems:

NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.