### PR TITLE
Define rqrcode as a runtime dependency.

### DIFF
--- a/barby.gemspec
+++ b/barby.gemspec
@@ -21,11 +21,12 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths     = ["lib"]
 
+  s.add_dependency             "rqrcode",         "~> 0.10"
+
   s.add_development_dependency "minitest",        "~> 5.11"
   s.add_development_dependency "bundler",         "~> 1.16"
   s.add_development_dependency "rake",            "~> 10.0"
   s.add_development_dependency "semacode-ruby19", "~> 0.7"
-  s.add_development_dependency "rqrcode",         "~> 0.10"
   s.add_development_dependency "prawn",           "~> 2.2"
   s.add_development_dependency "cairo",           "~> 1.15"
 end


### PR DESCRIPTION
# Description
`rqrcode` needs to be a runtime dependency since it's used in `Barby::QrCode`: https://github.com/toretore/barby/blob/9ea6d21444b54d3ef89756526929666124941041/lib/barby/barcode/qr_code.rb#L1