### PR TITLE
Fix unmatched (: /(?:\d{2}|�){2,}/ exception when requireing the file.

### DIFF
--- a/lib/barby/barcode/code_128.rb
+++ b/lib/barby/barcode/code_128.rb
@@ -406,7 +406,7 @@ module Barby
     DGTS_RE = /\d{4,}/
 
     # pairs of digits and FNC1 characters
-    CODEC_CHARS_RE = /(?:\d{2}|#{FNC1}){2,}/
+    CODEC_CHARS_RE = /(?:\d{2}|\#{FNC1}){2,}/
 
     class << self
 


### PR DESCRIPTION
When this file is required, i get **unmatched (: /(?:\d{2}|�){2,}/** exception. Adding '\\' before use of FNC1 constant to escape properly.

We are using ruby 1.8.7 (i know, it's old), and Rails 1.6.2 (I know too) under Ubuntu 20.04. I don't know if other have this issue with newer version of ruby/rails. But in our case, that's solve the issue.