### PR TITLE
Add option to html_outputter for human readable below barcode

### DIFF
--- a/lib/barby/outputter/html_outputter.rb
+++ b/lib/barby/outputter/html_outputter.rb
@@ -38,6 +38,10 @@ module Barby
   #
   #   :class_name - A class name that will be added to the <table> in addition to barby-barcode
   #   :human_row - true or false, will add a human readable version below the barcode see above to style it
+  #   Should be used as @barcode.human_row = true NOT @barcode.human_row = 'true'
+  #   'true' will work since a string is true in Ruby, but to turn it off you have to be sure to use false without
+  #   any quotes around it. 
+  #
   class HtmlOutputter < Outputter
 
     register :to_html

--- a/lib/barby/outputter/html_outputter.rb
+++ b/lib/barby/outputter/html_outputter.rb
@@ -32,15 +32,17 @@ module Barby
   #   tr.barby-row {}
   #   td.barby-cell { width: 3px; height: 3px; }
   #   td.barby-cell.on { background: #000; }
+  #   tr.human_row { text-align: center; font-family: "Arial Black"; }
   #
   # Options:
   #
   #   :class_name - A class name that will be added to the <table> in addition to barby-barcode
+  #   :human_row - true or false, will add a human readable version below the barcode see above to style it
   class HtmlOutputter < Outputter
 
     register :to_html
 
-    attr_accessor :class_name
+    attr_accessor :class_name, :human_readable
 
 
     def to_html(options = {})
@@ -84,7 +86,20 @@ module Barby
     end
 
     def stop
-      '</tbody></table>'
+      if barcode.two_dimensional?
+        '</tbody></table>'
+      else
+        # "<tr class='character_row'>#{human_row}</tr></tbody></table>"
+        (human_readable ? "#{human_row}" : '')+'</tbody></table>'
+      end
+    end
+
+    def human_row
+      last_row = "<tr class='human_row' style='text-align:center;'>"
+      barcode.to_s.split('').each do |c|
+        last_row << "<td colspan='#{(rows[0].scan('</td>').length/barcode.to_s.length)}'>#{c}</td>"
+      end
+      last_row
     end
 
 

--- a/lib/barby/outputter/html_outputter.rb
+++ b/lib/barby/outputter/html_outputter.rb
@@ -37,10 +37,10 @@ module Barby
   # Options:
   #
   #   :class_name - A class name that will be added to the <table> in addition to barby-barcode
-  #   :human_row - true or false, will add a human readable version below the barcode see above to style it
-  #   Should be used as @barcode.human_row = true NOT @barcode.human_row = 'true'
+  #   :human_readable - true or false, will add a human readable version below the barcode see above to style it
+  #   Should be used as @barcode.human_readable = true NOT @barcode.human_readable = 'true'
   #   'true' will work since a string is true in Ruby, but to turn it off you have to be sure to use false without
-  #   any quotes around it. 
+  #   any quotes around it.
   #
   class HtmlOutputter < Outputter
 

--- a/test/outputter/html_outputter_test.rb
+++ b/test/outputter/html_outputter_test.rb
@@ -38,8 +38,16 @@ class HtmlOutputterTest < Barby::TestCase
   end
 
   it 'should add the human readable below barcode' do
-    @outputter.human_readable = 'true'  # this test relies on data = 'BARBY' in before action above
+    @outputter.human_readable = true  # this test relies on data = 'BARBY' in before action above
     assert_equal "<tr class='human_row' style='text-align:center;'><td colspan='18'>B</td><td colspan='18'>A</td><td colspan='18'>R</td><td colspan='18'>B</td><td colspan='18'>Y</td></tbody></table>", @outputter.stop
+  end
+
+  it 'should remove the human readable below barcode' do
+    @outputter.human_readable = true  # this test relies on data = 'BARBY' in before action above
+    assert_equal "<tr class='human_row' style='text-align:center;'><td colspan='18'>B</td><td colspan='18'>A</td><td colspan='18'>R</td><td colspan='18'>B</td><td colspan='18'>Y</td></tbody></table>", @outputter.stop
+    @outputter.human_readable = false
+    assert_equal "</tbody></table>", @outputter.stop
+
   end
 
   it 'should build the expected cells' do

--- a/test/outputter/html_outputter_test.rb
+++ b/test/outputter/html_outputter_test.rb
@@ -37,6 +37,11 @@ class HtmlOutputterTest < Barby::TestCase
     assert_equal '</tbody></table>', @outputter.stop
   end
 
+  it 'should add the human readable below barcode' do
+    @outputter.human_readable = 'true'  # this test relies on data = 'BARBY' in before action above
+    assert_equal "<tr class='human_row' style='text-align:center;'><td colspan='18'>B</td><td colspan='18'>A</td><td colspan='18'>R</td><td colspan='18'>B</td><td colspan='18'>Y</td></tbody></table>", @outputter.stop
+  end
+
   it 'should build the expected cells' do
     assert_equal ['<td class="barby-cell on"></td>', '<td class="barby-cell off"></td>', '<td class="barby-cell off"></td>', '<td class="barby-cell on"></td>'],
       @outputter.cells_for([true, false, false, true])


### PR DESCRIPTION
In using the HTML outputter I found that I wanted to show the barcode data in human readable format below the barcode. Almost all barcodes on things like SKUs etc. have this in case you don't have a scanner handy, you still can see what the barcode says. Adding this after the fact, at least in Rails, is a real hassle. You have to use javascript to modify the barcode `<table>` and turbolinks can make it flakey. It was much easier to do it in the generator itself where I already had access to the needed variable. 

I added the option `human_readable` that is set like the `class_name` option. 
`@barcode.human_readable = true`

This causes the `stop` method to add html code that creates a `<tr></tr>` below the barcode row. It takes the data from the barcode and divides the characters each into their own `<td colspan="x"></td>` element. x is generated by counting the number of `</td>` elements in the barcode row and dividing that by the character count of the barcode data. It places each character into those  `<td>` elements and centers the text. The row is given a class that allows for styling. 

Added a test to confirm `human_readable` option works. 

All test passing except other generators which are skipped? Also the data-matrix test fails because I can't get semacode gem to install on my Mac.

If the barcode is 2D then the option is ignored


<img width="420" alt="Screen Shot 2022-06-18 at 21 58 34" src="https://user-images.githubusercontent.com/720006/174466653-59d5d0ad-3a5f-4f55-9465-22395ddf722c.png">
 