### PR TITLE
Replace deprecated MiniTest by Minitest

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require 'minitest/spec'
 
 module Barby
-  class TestCase < MiniTest::Spec
+  class TestCase < Minitest::Spec
 
     include Barby
 


### PR DESCRIPTION
MiniTest namespace is not supported by the version of minitest gem shipped with ruby3.3.