### PR TITLE
Reduce gem size by excluding test files

### DIFF
--- a/barby.gemspec
+++ b/barby.gemspec
@@ -15,9 +15,7 @@ Gem::Specification.new do |s|
 
   s.extra_rdoc_files  = ["README.md"]
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.test_files.delete("test/outputter/rmagick_outputter_test.rb")
+  s.files         = `git ls-files bin lib vendor`.split($/) + ["CHANGELOG", "LICENSE", "README.md"]
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths     = ["lib"]
 


### PR DESCRIPTION
This pull request updates the *.gemspec file to optimize the gem package size and structure

```bash
$ gem build -o before.tar.gz

$ git switch reduce-gem-size

$ gem build -o after.tar.gz

$ du -sh before.tar.gz after.tar.gz
100K	before.tar.gz
 84K	after.tar.gz
 ```
 
| Metric | Before | After | Saved                 |
|--------|--------|-------|-----------------------|
| Size   | 100K   | 84K   | −16K (⏷ −16%)     |


###  whitch files was deleted?

```diff
data
-├── .gitignore
-├── barby.gemspec
 ├── bin
 │   └── barby
 ├── CHANGELOG
-├── Gemfile
 ├── lib
 │   ├── barby
 │   │   ├── barcode
 │   │   │   ├── bookland.rb
 │   │   │   ├── codabar.rb
 │   │   │   ├── code_128.rb
 │   │   │   ├── code_25_iata.rb
 │   │   │   ├── code_25_interleaved.rb
 │   │   │   ├── code_25.rb
 │   │   │   ├── code_39.rb
 │   │   │   ├── code_93.rb
 │   │   │   ├── data_matrix.rb
 │   │   │   ├── ean_13.rb
 │   │   │   ├── ean_8.rb
 │   │   │   ├── gs1_128.rb
 │   │   │   ├── pdf_417.rb
 │   │   │   ├── qr_code.rb
 │   │   │   └── upc_supplemental.rb
 │   │   ├── barcode.rb
 │   │   ├── outputter
 │   │   │   ├── ascii_outputter.rb
 │   │   │   ├── cairo_outputter.rb
 │   │   │   ├── html_outputter.rb
 │   │   │   ├── pdfwriter_outputter.rb
 │   │   │   ├── png_outputter.rb
 │   │   │   ├── prawn_outputter.rb
 │   │   │   ├── rmagick_outputter.rb
 │   │   │   └── svg_outputter.rb
 │   │   ├── outputter.rb
 │   │   ├── vendor.rb
 │   │   └── version.rb
 │   └── barby.rb
 ├── LICENSE
-├── Rakefile
 ├── README.md
-├── test
-│   ├── barcodes.rb
-│   ├── bookland_test.rb
-│   ├── codabar_test.rb
-│   ├── code_128_test.rb
-│   ├── code_25_iata_test.rb
-│   ├── code_25_interleaved_test.rb
-│   ├── code_25_test.rb
-│   ├── code_39_test.rb
-│   ├── code_93_test.rb
-│   ├── data_matrix_test.rb
-│   ├── ean13_test.rb
-│   ├── ean8_test.rb
-│   ├── outputter
-│   │   ├── cairo_outputter_test.rb
-│   │   ├── html_outputter_test.rb
-│   │   ├── pdfwriter_outputter_test.rb
-│   │   ├── png_outputter_test.rb
-│   │   ├── prawn_outputter_test.rb
-│   │   ├── rmagick_outputter_test.rb
-│   │   └── svg_outputter_test.rb
-│   ├── outputter_test.rb
-│   ├── pdf_417_test.rb
-│   ├── qr_code_test.rb
-│   ├── test_helper.rb
-│   └── upc_supplemental_test.rb
 └── vendor
     └── Pdf417lib-java-0.91
         └── lib
             ├── Pdf417lib.jar
             └── Pdf417lib.java
```

ps: you can see on [rails repo](https://github.com/rails/rails/blob/main/actioncable/actioncable.gemspec#L20)